### PR TITLE
run prisma generate first before npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
+    "postinstall": "prisma generate",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
vercel doesn't generate prisma during building we are doing this manually by running prisma generate before npm next build.
you are able to do this in vercel itself but we wouldn't want to deal with that in the future